### PR TITLE
fix: restore frontend styles, support WP 6.0-7.0 and PHP 7.4-8.5

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,61 +1,137 @@
-# A set of files you probably don't want in your WordPress.org distribution
-.babelrc
-.deployignore
-.distignore
-.editorconfig
-.eslintignore
-.eslintrc
-.gitmodules
+# A set of files you probably don't want in your WordPress.org distribution.
+#
+# Consumed by `wp dist-archive`. A line that resolves to a real directory is
+# automatically expanded to `<dir>/*`, so bare directory names are fine.
+
+# --- Version control ---
 .git
 .gitignore
-.github
 .gitattributes
+.gitmodules
+.github
 .gitlab-ci.yml
+
+# --- CI / deployment ---
 .travis.yml
+.circleci/config.yml
+bitbucket-pipelines.yml
+behat.yml
+dependencies.yml
+wp-cli.local.yml
+.deployignore
+.distignore
+
+# --- Editor / OS / tooling ---
+.editorconfig
+.idea
+.vscode
+.claude
 .DS_Store
 Thumbs.db
-behat.yml
-bitbucket-pipelines.yml
-bin
-.circleci/config.yml
-composer.json
-composer.lock
-dependencies.yml
+.env
+.env.*
+logs
+*.log
+coverage
+
+# --- Build config & sources (compiled output lives in dist/) ---
+src
+util
+config
+webpack.config.js
 Gruntfile.js
+gulpfile.js
+rollup.config.js
+vite.config.js
+postcss.config.js
+tsconfig.json
+
+# --- Babel ---
+.babelrc
+.babelrc.js
+.babelrc.json
+babel.config.js
+babel.config.json
+
+# --- Linting & formatting ---
+.eslintrc
+.eslintrc.js
+.eslintrc.json
+.eslintrc.yml
+.eslintignore
+.eslintcache
+.prettierrc
+.prettierrc.js
+.prettierrc.json
+.prettierignore
+prettier.config.js
+.stylelintrc
+.stylelintrc.js
+.stylelintrc.json
+.phpcs.xml
+.phpcs.xml.dist
+phpcs.xml
+phpcs.xml.dist
+
+# --- Package managers ---
 package.json
 package-lock.json
+yarn.lock
+pnpm-lock.yaml
+.npmrc
+.nvmrc
+.yarnrc
+.yarnrc.yml
+composer.json
+composer.lock
+node_modules
+node_modules/**/*.*
+vendor
+
+# --- Tests & local environments ---
+tests
+bin
 phpunit.xml
 phpunit.xml.dist
 multisite.xml
 multisite.xml.dist
-.phpcs.xml
-phpcs.xml
-.phpcs.xml.dist
-phpcs.xml.dist
-README.md
-webpack.config.js
-wp-cli.local.yml
-yarn.lock
-tests
-vendor
-node_modules
-*.sql
-*.tar.gz
-*.zip
-gulpfile.js
-.git
-node_modules/**/*.*
-**/*.zip
-src
-util
+.wp-env.json
+.wp-env.override.json
+
+# --- Docs & repo assets (readme.txt is the only one WordPress.org needs) ---
+*.md
 .wordpress-org
-.idea
+
+# --- Submodule sources: ship only the built style-handler ---
+# An initialised submodule leaves a `.git` *file* (a gitlink pointer). The root
+# `.git` entry expands to `.git/*` because it is a directory, so it cannot match
+# this one — it needs its own explicit path.
+lib/style-handler/.git
 controls
-config
 lib/style-handler/helpers.js
 lib/style-handler/style-handler.js
 lib/style-handler/gitignore
 lib/style-handler/dist/index.js.map
 lib/style-handler/README.md
-dist/*.*.map
 
+# --- Orphaned Font Awesome 4 webfonts ---
+# assets/css/font-awesome5.css is FA5 and references only fa-solid-900,
+# fa-brands-400 and fa-regular-400. These FA4 leftovers are referenced by no
+# CSS, JS, PHP or src file and cost ~1.1 MB uncompressed.
+assets/fonts/FontAwesome.otf
+assets/fonts/fontawesome-webfont.*
+
+# --- Legacy webfont formats ---
+# Every @font-face lists woff2/woff/ttf ahead of these, so a browser new enough
+# to run the block editor never requests them. .eot is IE-only (WordPress
+# dropped IE11 in 5.8); SVG fonts were removed from Chrome 38 and only ever
+# worked in Safari <= 4.1 / Android <= 4.3. Saves ~2.2 MB.
+assets/fonts/*.eot
+assets/fonts/*.svg
+
+# --- Archives & build artefacts ---
+*.map
+*.sql
+*.tar.gz
+*.zip
+**/*.zip

--- a/compatibility-report.md
+++ b/compatibility-report.md
@@ -1,0 +1,221 @@
+# Price Table Block — Compatibility Report
+
+**Plugin:** Price Table Block (`price-table-block`)
+**Version:** 1.2.7 → **1.5.0**
+**Branch:** `price-table-block-dev` (branched off `latest`)
+**Date of audit:** 2026-08-09
+**Nothing committed or pushed — all changes left in the working tree.**
+
+---
+
+## 1. Detected original baseline
+
+Header/readme claims were cross-checked against the actual code.
+
+| | Declared before | Real, inferred from code |
+|---|---|---|
+| PHP | *(not declared at all)* | **5.6** originally written for, but silently raised to **8.0** by a later commit |
+| WordPress | `Requires at least: 5.6`, `Tested up to: 6.5` | **5.6** intended; code paths actually assumed **5.8+** |
+
+Code evidence for the PHP floor:
+
+- `includes/font-loader.php:24-27` — `get_instance( ...$args )` / `new static( ...$args )`: **variadics ⇒ PHP 5.6+**.
+- `price-table-block.php:44` — `[ ... ]` short array syntax ⇒ PHP 5.4+.
+- `price-table-block.php:37` — `throw new Error(...)`: the `Error` class only exists in **PHP 7.0+**. On PHP 5.x this line is itself a fatal (`Class 'Error' not found`).
+- `includes/helpers.php:47` — `str_contains()` is a **PHP 8.0** function, introduced by commit `5929cf4` ("compatibility support with wordpress 6.5"). WP core only polyfills it from **WP 5.9**. So the shipped plugin hard-fataled on any PHP 7.x site running WP 5.6–5.8, despite the readme advertising WP 5.6 support.
+- No return types, no `??`, no nullable types, no arrow functions, no `match`, no typed properties, no enums ⇒ nothing above 7.0 is required once `str_contains` is removed.
+
+Code evidence for the WP floor:
+
+- `register_block_type` + `block.json` with `"apiVersion": 2` ⇒ **WP 5.6+** (apiVersion 2 landed in 5.6).
+- `Price_Table_Helper::get_block_register_path()` passes a **directory** to `register_block_type()` — that signature only exists from **WP 5.8**.
+- `includes/helpers.php:69` — `site-editor.php` handling ⇒ WP 5.9-era code.
+- `render_block` filter ⇒ WP 5.0+.
+- No REST routes, no `$wpdb` queries, no nonce-guarded/state-changing endpoints, no admin forms, no translation calls in PHP ⇒ the usual REST `permission_callback`, `$wpdb->prepare()`, nonce/capability and WP 6.7 early-textdomain classes of issue do not apply here.
+
+**Conclusion:** the plugin's real, intended range is PHP 5.6+ / WP 5.6+, but as shipped it was broken below PHP 8.0 and below WP 5.8.
+
+---
+
+## 2. Target range
+
+Live version check performed **2026-08-09**:
+
+- `https://www.php.net/releases/index.php?json&max=3` → latest stable **PHP 8.5.9**; actively supported branches: 8.2, 8.3, 8.4, 8.5.
+- `https://api.wordpress.org/core/version-check/1.7/` → current release **WordPress 7.0.3**.
+- [WordPress 7.0 Field Guide](https://make.wordpress.org/core/2026/05/14/wordpress-7-0-field-guide/) — WP Core minimum PHP is now **7.4**; the iframed post editor is only enforced when **every** block on the post is Block API **v3 or higher**, so `apiVersion: 2` blocks stay supported and simply keep the non-iframed editor.
+- [PHP 8.5 deprecated features](https://www.php.net/manual/en/migration85.deprecated.php) — new deprecations are backtick shell operator, non-canonical casts `(integer)`/`(boolean)`, `null` as an array offset or `array_key_exists()` key, output inside output handlers, `xml_parser_free()`, `__sleep`/`__wakeup`. Checked: the plugin uses none of these except the `null`-array-offset pattern, which is fixed below. `(float)` is a canonical cast and is unaffected.
+
+**Verified target range: PHP 7.0 → 8.5, WordPress 5.6 → 7.0.**
+
+Per-version checklist walked: PHP 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4, 8.5 · WP 5.6, 5.7, 5.8, 5.9, 6.0–6.9, 6.10, 7.0.
+
+---
+
+## 3. Issues found
+
+Line numbers refer to the code **before** the fixes (`git diff` shows the after state).
+
+| # | File:line | Issue | Breaks on | Severity |
+|---|---|---|---|---|
+| 1 | `includes/helpers.php:47` | `str_contains()` — PHP 8.0 function, WP polyfills it only from 5.9 | Fatal on PHP < 8.0 with WP < 5.9 | **Critical** |
+| 2 | `price-table-block.php:27` | `require_once .../lib/style-handler/style-handler.php` unguarded; `lib/style-handler` is an **uninitialised git submodule** (empty dir in this checkout) | Fatal on every PHP/WP version whenever the submodule is missing | **Critical** |
+| 3 | `includes/helpers.php:49,54,55,87` | `$controls_dependencies = include_once …` — `include_once` returns `bool true` when already loaded; `array_merge(true, …)` is a `TypeError` | Fatal on PHP 8.0+ (silent warnings on 7.x) | **High** |
+| 4 | `includes/helpers.php:94` | `(float) get_bloginfo('version') <= 5.6` chooses the block-name vs block-path form; the path form needs WP 5.8. WP 5.7 got the path and failed to register. Float casts are also lossy — `"6.10"` → `6.1` | Block never registers on WP 5.7; version logic wrong on any x.10+ release | **High** |
+| 5 | `includes/helpers.php:49` | No `file_exists()` before reading `dist/modules.asset.php` | Warning + downstream fatal when `dist/` is absent | **High** |
+| 6 | `price-table-block.php:44,57` | `$script_asset['dependencies']` / `['version']` used without checking the generated asset file returned a well-formed array | `TypeError` on PHP 8 with a stale/partial `index.asset.php` | **Medium** |
+| 7 | `price-table-block.php:96,111` | `filemtime()` called with no `file_exists()` guard | `filemtime(): stat failed` warning on PHP 8; version silently becomes `false` | **Medium** |
+| 8 | `includes/helpers.php:47` | `$_SERVER['QUERY_STRING']` read raw — no `wp_unslash()` / `sanitize_text_field()` | All versions (hygiene / WPCS) | **Medium** |
+| 9 | `includes/font-loader.php:68` | `$googleFontFamily[$attributes[$key]]` — a `null` attribute value becomes a `null` array key | Deprecated in PHP 8.5; empty-key silently in earlier versions | **Medium** |
+| 10 | `includes/font-loader.php:94` | `trim( $font )` with a possibly-`null` font name | `Passing null to parameter` deprecation on PHP 8.1+ | **Medium** |
+| 11 | `includes/font-loader.php:51` | `$block['blockName']` accessed without `isset()`; `$block['attrs']` not verified as an array | Undefined-key warning on PHP 8 for blocks with no `blockName` | **Medium** |
+| 12 | `includes/font-loader.php:82` | `$eb_settings['googleFont']` — array offset used without confirming `get_option()` returned an array | Warning on PHP 7.4+/8 if the option is corrupt | **Low** |
+| 13 | `price-table-block.php:1` | No `if ( ! defined( 'ABSPATH' ) ) exit;` guard in the main plugin file | All versions (direct-access hardening) | **Low** |
+| 14 | `price-table-block.php:29` | Global function `create_block_pricing_table_block_init()` declared with no `function_exists()` guard | Fatal redeclare if a sibling EB plugin ever ships the same name | **Low** |
+| 15 | `includes/helpers.php:53,85` | `PRICE_TABLE_BLOCKS_ADMIN_URL . '/dist/…'` — constant already ends in `/`, producing `…plugins/price-table-block//dist/modules.js` | Cosmetic; some CDNs/security plugins reject the double slash | **Low** |
+| 16 | `includes/post-meta.php:11` | `add_filter( 'init', … )` used to register an action callback | Works (aliases), but wrong API | **Low** |
+| 17 | `price-table-block.php:31`, `package.json:3` | Version literals contain a leading space: `" 1.2.7"`. Constant is used as an asset `?ver=` value | Cosmetic; produces `?ver=%201.2.7` | **Low** |
+| 18 | `includes/helpers.php:41` | `enqueues()` dereferences `PRICE_TABLE_BLOCKS_ADMIN_PATH`/`_URL` without a `defined()` guard | Fatal if the file is loaded outside the normal init order | **Low** |
+| 19 | `price-table-block.php:81,88,103` | Three `wp_register_style()` calls omit the `$ver` argument, so WP stamps the **WordPress** version instead of the plugin's | Stale CSS after a plugin update | **Low** |
+
+Checked and found **clean**: no `mysql_*`, `create_function()`, `each()`, `ereg*`, `split()`, `money_format()`, `strftime()`, `utf8_encode/decode`, `FILTER_SANITIZE_STRING`, `${var}` interpolation, curly-brace string offsets, implicit nullable parameters, dynamic property creation, `ArrayAccess`/`Iterator`/`JsonSerializable` implementations needing `#[\ReturnTypeWillChange]`, optional-before-required parameters, `$wpdb` usage, REST routes, unescaped output, or deprecated jQuery/jQuery-Migrate patterns (`assets/js/eb-animation-load.js` is vanilla JS).
+
+---
+
+## 4. Fixes applied
+
+| Issue | Fix |
+|---|---|
+| 1 | `str_contains($qs, 'gutenberg-edit-site')` → `strpos($qs, 'gutenberg-edit-site') !== false`. Identical semantics, works on PHP 5.x → 8.5. |
+| 2 | The `style-handler` require is now wrapped in `file_exists()`. When the submodule is present nothing changes; when it is missing the site stays up instead of white-screening. |
+| 3, 5 | `include_once` → `file_exists()` + `include`, result normalised through `is_array()`; `dependencies` and `version` read via `isset()` into `$controls_deps` / `$controls_version`, which the register/enqueue calls now use. |
+| 4 | `get_block_register_path()` rewritten to `version_compare( get_bloginfo('version'), '5.8', '>=' )` — path form on WP 5.8+, block name below. **WP 5.6 and 5.8+ behaviour is unchanged; WP 5.7 changes from broken to working.** |
+| 6 | `$script_asset` normalised the same way; `$asset_dependencies` / `$asset_version` fall back to an empty array and the plugin version. |
+| 7 | Both `filemtime()` calls guarded with `file_exists()`, falling back to `PRICE_TABLE_BLOCKS_VERSION`. |
+| 8 | `$_SERVER['QUERY_STRING']` now read through `isset()` + `wp_unslash()` + `sanitize_text_field()` into `$query_string`. |
+| 9 | `get_fonts_family()` skips attribute values that are unset, non-string, or empty — those produced no usable font name anyway. Also returns early when `$attributes` is not an array. |
+| 10 | `trim( (string) $font )`. |
+| 11 | `get_fonts_on_render_block()` verifies `$block` and `$block['attrs']` are arrays and reads `blockName` through `isset()`. |
+| 12 | `get_option('eb_settings', [])` result coerced with `is_array()`. |
+| 13 | `ABSPATH` guard added to the main plugin file. |
+| 14 | Init function wrapped in `if ( ! function_exists( … ) )`. |
+| 15 | Removed the duplicated leading slash on the two `dist/` URLs. |
+| 16 | `add_filter('init', …)` → `add_action('init', …)`. |
+| 17 | Version literals cleaned and bumped to `1.5.0` in the header, `PRICE_TABLE_BLOCKS_VERSION`, `readme.txt` `Stable tag`, and `package.json`. |
+| 18 | `enqueues()` returns early unless both plugin constants are defined. |
+| 19 | The three `wp_register_style()` calls now pass `PRICE_TABLE_BLOCKS_VERSION`. |
+
+Metadata updated:
+
+- `price-table-block.php` header — `Version: 1.5.0`, added `Requires at least: 6.0` and `Requires PHP: 7.4`.
+- `readme.txt` — `Tested up to: 7.0`, added `Requires PHP: 7.4`, `Requires at least: 6.0`, `Stable tag: 1.5.0`, new `= 1.5.0 - 09/08/2026 =` changelog entry.
+- `package.json` — `"version": "1.5.0"`.
+
+No feature, UI, block markup, attribute, option name, hook name, or public API was changed.
+
+---
+
+## 5. Flagged — not changed, needs your decision
+
+1. **`eb_wp_version` is still a lossy float** (`includes/helpers.php`). The bundled controls bundle does `n >= 5.8 ? registerBlockType({name, …}) : registerBlockType(name, …)`, so the value has to stay numerically comparable — sending a string would make the comparison `NaN` and take the wrong branch. `(float) "6.10"` is `6.1`, which happens to stay `>= 5.8`, so nothing breaks today, but the encoding is fragile. Proper fix is to send both a raw version string and switch the JS to a real comparison — that requires rebuilding the `controls` submodule, so it is out of scope here.
+
+2. **`throw new Error(...)` when `dist/index.asset.php` is missing** (`price-table-block.php`). This runs on `init` and takes the whole site down rather than just the block. Recommendation: replace with an `admin_notice` + early `return`. Not done because it changes user-visible failure behaviour.
+
+3. **`block.json` is `"apiVersion": 2`.** Confirmed still supported in WP 7.0 — no fatal, no deprecation. The trade-off is that a v2 block on a post disables the iframed editor for that post. Bumping to v3 is a real editor-rendering change (styles must be enqueued into the iframe) and needs QA, so it is left alone.
+
+4. **`dist/` was built with `@wordpress/scripts` ^19.2.2** and lists `react` / `react-dom` as dependencies. WP 7.0 ships React 19 in the editor. Nothing in the audited PHP breaks, but the JS bundle should be rebuilt against current `@wordpress/scripts` and smoke-tested in the WP 7.0 editor before release. Out of scope for a PHP compatibility pass.
+
+5. **Adding `$ver` to three stylesheets** (issue 19) changes the `?ver=` query string on those asset URLs from the WordPress version to `1.5.0`. Behaviour is identical; visitors get one cache-bust on upgrade. Say the word if you want those reverted.
+
+6. ~~**`Requires at least: 5.6` was kept**~~ — **resolved 2026-08-09: the floor was raised to WP 6.0 on request.** One consequence remains open: `Price_Table_Helper::get_block_register_path()` exists solely to hand a block *name* rather than a *directory* to `register_block_type()` on WP 5.6/5.7. At a 6.0 floor its `version_compare( …, '5.8', '>=' )` is always true, so the fallback branch is now dead code. It is harmless and was left in place — say the word to delete the helper and inline `PRICE_TABLE_BLOCKS_ADMIN_PATH` at the call site.
+
+7. ~~**`Requires PHP: 7.0` is the honest code floor**~~ — **resolved 2026-08-09: raised to PHP 7.4 on request**, matching WP Core's own minimum. Note the code still avoids `str_contains()` in favour of `strpos()`: `str_contains()` is PHP **8.0**, so it stays off-limits at a 7.4 floor. Do not "modernise" that line back.
+
+---
+
+## 6. Old-vs-new conflicts
+
+None that could not be reconciled. The one genuine tension — PHP 8's `str_contains()` versus PHP 7.x support — was resolved with `strpos()`, which is correct on the entire range with no trade-off. The WP 5.7 registration gap was closed by moving the boundary to the version where the API actually changed (5.8) rather than the version the old code guessed (5.6).
+
+---
+
+## 7. Declared compatibility after this pass
+
+```
+Requires at least: 6.0
+Tested up to:      7.0
+Requires PHP:      7.4
+Stable tag:        1.5.0
+```
+
+---
+
+## 7b. Functional investigation — "background colour not showing on frontend" (2026-08-09)
+
+### Root cause: the style pipeline had no server-side half
+
+The block does **not** emit its own `<style>` tag in `save.js`; the saved markup carries
+only `blockId` classes. The real chain is:
+
+1. `edit.js` renders `<Style {...props} />` → `StyleComponent` (from the `controls`
+   submodule) generates the CSS and stores it in the block's **`blockMeta` attribute**.
+2. On `save_post` — and on frontend load via the `wp` hook — `lib/style-handler`
+   parses the post content, collects every block's `blockMeta`, and writes
+   `wp-content/uploads/eb-style/eb-style-<post-id>.min.css`.
+3. `enqueue_frontend_assets()` enqueues that file on `wp_enqueue_scripts`.
+
+`lib/style-handler` is a **git submodule and was never initialised** in this checkout,
+so step 2 never existed. No CSS file was written and none was enqueued. This is why
+*every* styling control — background, typography, padding, border, ribbon — had no
+frontend effect, not just background colour. Step 1 still ran, which is why the editor
+preview looked correct: the two halves fail independently.
+
+Fixed with `git submodule update --init --recursive`. Note style-handler is
+block-name agnostic (it keys off `blockMeta`, not the block name), so the
+`price-table-block/` vs `essential-blocks/` namespace difference is not a factor.
+
+### Bug found and fixed: responsive styles dead in the editor preview
+
+`StyleComponent` builds the editor's media queries from
+`EssentialBlocksLocalize.responsiveBreakpoints.tablet` / `.mobile`, but
+`includes/helpers.php` localised only `eb_wp_version`, `rest_rootURL` and
+`fontAwesome`. Verified in the **shipped** `dist/modules.js`, not just source:
+
+```
+"@media all and (max-width: ".concat(…EssentialBlocksLocalize.responsiveBreakpoints…?.tablet,"px) {
+```
+
+With the key absent this emitted `@media all and (max-width: undefinedpx)`, an invalid
+query, so every tablet and mobile rule was discarded **in the editor preview**. The
+frontend was unaffected because the style handler builds those media queries in PHP.
+
+Fix: added `Price_Table_Helper::get_responsive_breakpoints()`, which mirrors
+`EbStyleHandlerParseCss::get_responsive_breakpoints()` — same `eb_settings`
+option, same 1024/767 defaults, same JSON-string handling — and localised it.
+It is deliberately read-only, unlike the style handler, which writes the option back.
+
+All five sibling plugins (`button-group`, `number-counter`, `image-gallery-block`,
+`infobox`, `flipbox`) have the identical omission and need the same fix.
+
+### Observations, not fixed
+
+- `dist/frontend.js` (icon helpers, `window.eb_frontend`) is built but **never
+  registered or enqueued** by any PHP. `save.js` bakes icons into static markup, so
+  nothing needs it. Dead build output.
+- The Google Fonts URL ends with a trailing `|` separator. Google ignores it; cosmetic.
+- `EssentialBlocksLocalize` is a single global shared by every EB-family plugin, so the
+  last-enqueued plugin's payload wins. The bundle also reads `all_blocks`, which this
+  plugin does not localise; it is unreachable here because the guard is
+  `/^essential-blocks\//` and this block is `price-table-block/pricing-table`.
+  Deliberately **not** added — supplying an empty `all_blocks` could clobber real data
+  from the main Essential Blocks plugin and break its block-visibility filtering.
+
+## 8. Verification performed
+
+- `php -l` on every PHP file in the plugin (excluding `node_modules`) — **7/7 clean**, including the generated `dist/*.asset.php` files.
+- **Runtime smoke harness** (WordPress functions stubbed, `error_reporting(E_ALL)`, PHP **8.5.8**) executing `create_block_pricing_table_block_init()`, `Price_Table_Helper::enqueues()` on both the `post.php` and the `themes.php?page=gutenberg-edit-site` branches, and `Price_Table_Font_Loader` fed deliberately hostile attributes (`null`, integer, missing `blockName`, `null` `attrs`). Run against WP versions **5.6, 5.7, 5.8, 6.5, 6.10, 7.0.3**.
+  - **Zero warnings, zero notices, zero deprecations** on every combination.
+  - Registration path verified: block **name** on 5.6/5.7, block **directory** on 5.8+.
+  - The empty `lib/style-handler` submodule in this checkout no longer fatals — proof that the `file_exists()` guard works.
+- PHP 7.0–8.4 could not be executed (only PHP 8.5.8 is installed locally); compatibility on those versions is established by static inspection — no syntax or function above the PHP 7.0 baseline remains in the codebase.
+- `phpcs` is **not installed** on this machine (`phpcs -i` unavailable), so the WordPress Coding Standards sweep was skipped rather than installed without asking.

--- a/includes/font-loader.php
+++ b/includes/font-loader.php
@@ -13,7 +13,7 @@ class Price_Table_Font_Loader {
     protected static $instances = null;
 
     public static $gfonts      = [];
-    private static $block_name = [];
+    private static $block_name = '';
 
     /**
      * Registers the plugin.
@@ -48,8 +48,9 @@ class Price_Table_Font_Loader {
      * @access public
      */
     public function get_fonts_on_render_block( $block_content, $block ) {
-        if ( isset( $block['attrs'] ) ) {
-            if ( 'essential-blocks' === self::$block_name || $block['blockName'] === self::$block_name ) {
+        if ( is_array( $block ) && isset( $block['attrs'] ) && is_array( $block['attrs'] ) ) {
+            $block_name = isset( $block['blockName'] ) ? $block['blockName'] : '';
+            if ( 'essential-blocks' === self::$block_name || $block_name === self::$block_name ) {
                 $fonts        = self::get_fonts_family( $block['attrs'] );
                 self::$gfonts = array_unique( array_merge( self::$gfonts, $fonts ) );
             }
@@ -64,9 +65,18 @@ class Price_Table_Font_Loader {
      * @access public
      */
     public static function get_fonts_family( $attributes ) {
+        if ( ! is_array( $attributes ) ) {
+            return [];
+        }
+
         $keys             = preg_grep( '/^(\w+)FontFamily/i', array_keys( $attributes ), 0 );
         $googleFontFamily = [];
         foreach ( $keys as $key ) {
+            // Skip null/non-scalar values: passing null on to trim()/str_replace()
+            // is deprecated as of PHP 8.1 and yields an empty font name anyway.
+            if ( ! isset( $attributes[$key] ) || ! is_string( $attributes[$key] ) || '' === $attributes[$key] ) {
+                continue;
+            }
             $googleFontFamily[$attributes[$key]] = $attributes[$key];
         }
         return $googleFontFamily;
@@ -81,6 +91,7 @@ class Price_Table_Font_Loader {
         $googleFont = true;
         if ( 'essential-blocks' === self::$block_name ) {
             $eb_settings = get_option( 'eb_settings', [] );
+            $eb_settings = is_array( $eb_settings ) ? $eb_settings : [];
             $googleFont  = ! empty( $eb_settings['googleFont'] ) ? $eb_settings['googleFont'] : 'true';
         }
 
@@ -94,7 +105,7 @@ class Price_Table_Font_Loader {
                 $gfonts      = '';
                 $gfonts_attr = ':100,100italic,200,200italic,300,300italic,400,400italic,500,500italic,600,600italic,700,700italic,800,800italic,900,900italic';
                 foreach ( $fonts as $font ) {
-                    $gfonts .= str_replace( ' ', '+', trim( $font ) ) . $gfonts_attr . '|';
+                    $gfonts .= str_replace( ' ', '+', trim( (string) $font ) ) . $gfonts_attr . '|';
                 }
                 if ( ! empty( $gfonts ) ) {
                     $query_args = [

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -41,25 +41,63 @@ class Price_Table_Helper
     public function enqueues($hook)
     {
         global $pagenow;
+
+        if (!defined('PRICE_TABLE_BLOCKS_ADMIN_PATH') || !defined('PRICE_TABLE_BLOCKS_ADMIN_URL')) {
+            return;
+        }
+
+        /**
+         * str_contains() is PHP 8.0+ (polyfilled by WP core only since 5.9), so
+         * strpos() is used instead to keep the whole supported range working.
+         */
+        $query_string = isset($_SERVER['QUERY_STRING'])
+            ? sanitize_text_field(wp_unslash($_SERVER['QUERY_STRING']))
+            : '';
+
         /**
          * Only for Admin Add/Edit Pages
          */
-        if ($hook == 'post-new.php' || $hook == 'post.php' || $hook == 'site-editor.php' || ($pagenow == 'themes.php' && !empty($_SERVER['QUERY_STRING']) && str_contains($_SERVER['QUERY_STRING'], 'gutenberg-edit-site'))) {
+        if ($hook == 'post-new.php' || $hook == 'post.php' || $hook == 'site-editor.php' || ($pagenow == 'themes.php' && !empty($query_string) && strpos($query_string, 'gutenberg-edit-site') !== false)) {
 
-            $controls_dependencies = include_once PRICE_TABLE_BLOCKS_ADMIN_PATH . '/dist/modules.asset.php';
+            /**
+             * `include_once` returns bool true when the file was already loaded,
+             * which fatals on PHP 8 once the result is used as an array. Read the
+             * generated asset file with `include` and normalise the result.
+             */
+            $controls_asset_path   = PRICE_TABLE_BLOCKS_ADMIN_PATH . '/dist/modules.asset.php';
+            $controls_dependencies = file_exists($controls_asset_path) ? include $controls_asset_path : array();
+
+            if (!is_array($controls_dependencies)) {
+                $controls_dependencies = array();
+            }
+            $controls_deps    = isset($controls_dependencies['dependencies']) && is_array($controls_dependencies['dependencies'])
+                ? $controls_dependencies['dependencies']
+                : array();
+            $controls_version = isset($controls_dependencies['version'])
+                ? $controls_dependencies['version']
+                : PRICE_TABLE_BLOCKS_VERSION;
 
             wp_register_script(
                 "eb-price-table-blocks-controls-util",
-                PRICE_TABLE_BLOCKS_ADMIN_URL . '/dist/modules.js',
-                 array_merge($controls_dependencies['dependencies'],['lodash']),
-                $controls_dependencies['version'],
+                PRICE_TABLE_BLOCKS_ADMIN_URL . 'dist/modules.js',
+                 array_merge($controls_deps,['lodash']),
+                $controls_version,
                 true
             );
 
             wp_localize_script('eb-price-table-blocks-controls-util', 'EssentialBlocksLocalize', array(
+                // Kept as a float: the bundled controls JS compares it numerically
+                // (`eb_wp_version >= 5.8`). Changing the type would break that check.
                 'eb_wp_version' => (float) get_bloginfo('version'),
                 'rest_rootURL' => get_rest_url(),
-				'fontAwesome' => "true"
+				'fontAwesome' => "true",
+                /**
+                 * StyleComponent builds the editor preview's media queries from
+                 * `EssentialBlocksLocalize.responsiveBreakpoints`. Without it the
+                 * editor emitted `@media all and (max-width: undefinedpx)`, so every
+                 * tablet/mobile rule was discarded in the editor preview.
+                 */
+                'responsiveBreakpoints' => self::get_responsive_breakpoints(),
             ));
 
             if ($hook == 'post-new.php' || $hook == 'post.php') {
@@ -82,20 +120,64 @@ class Price_Table_Helper
 
             wp_enqueue_style(
                 'essential-blocks-editor-css',
-                PRICE_TABLE_BLOCKS_ADMIN_URL . '/dist/modules.css',
+                PRICE_TABLE_BLOCKS_ADMIN_URL . 'dist/modules.css',
                 array('essential-blocks-iconpicker-css'),
-                $controls_dependencies['version'],
+                $controls_version,
                 'all'
             );
         }
     }
+    /**
+     * Responsive breakpoints used by the editor preview.
+     *
+     * Mirrors EbStyleHandlerParseCss::get_responsive_breakpoints() so the editor's
+     * media queries match the ones the style handler writes into the frontend CSS.
+     * Read-only on purpose — unlike the style handler, this never writes the option
+     * back, because it runs on every admin enqueue.
+     *
+     * @return array{tablet:int,mobile:int}
+     */
+    public static function get_responsive_breakpoints()
+    {
+        $defaults = array('tablet' => 1024, 'mobile' => 767);
+
+        $settings = get_option('eb_settings', array());
+        if (!is_array($settings) || !isset($settings['responsiveBreakpoints'])) {
+            return $defaults;
+        }
+
+        $breakpoints = $settings['responsiveBreakpoints'];
+        if (is_string($breakpoints)) {
+            if ('' === $breakpoints) {
+                return $defaults;
+            }
+            $breakpoints = json_decode(html_entity_decode(stripslashes($breakpoints)), true);
+        }
+
+        $breakpoints = is_array($breakpoints) ? $breakpoints : (array) $breakpoints;
+
+        return array(
+            'tablet' => isset($breakpoints['tablet']) && is_numeric($breakpoints['tablet'])
+                ? (int) $breakpoints['tablet']
+                : $defaults['tablet'],
+            'mobile' => isset($breakpoints['mobile']) && is_numeric($breakpoints['mobile'])
+                ? (int) $breakpoints['mobile']
+                : $defaults['mobile'],
+        );
+    }
+
     public static function get_block_register_path($blockname, $blockPath)
     {
-        if ((float) get_bloginfo('version') <= 5.6) {
-            return $blockname;
-        } else {
+        /**
+         * register_block_type() only accepts a block.json directory since WP 5.8;
+         * earlier releases must be handed the block name. version_compare() is used
+         * because a float cast of the version string is lossy ("6.10" becomes 6.1).
+         */
+        if (version_compare(get_bloginfo('version'), '5.8', '>=')) {
             return $blockPath;
         }
+
+        return $blockname;
     }
 }
 Price_Table_Helper::register();

--- a/includes/post-meta.php
+++ b/includes/post-meta.php
@@ -9,7 +9,7 @@ class Price_Table_Post_Meta
 {
     public function __construct()
     {
-        add_filter('init', array($this, 'register_meta'));
+        add_action('init', array($this, 'register_meta'));
     }
 
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pricing-table",
-	"version": " 1.2.6",
+	"version": "1.5.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pricing-table",
-			"version": "1.2.5",
+			"version": "1.5.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"array-move": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pricing-table",
-	"version": " 1.2.7",
+	"version": "1.5.0",
 	"description": "EB Pricing Table will let you create effective product pricing table with perfect styling to get more sales from your prospective buyers.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/price-table-block.php
+++ b/price-table-block.php
@@ -4,15 +4,22 @@
  * Plugin Name:     Price Table Block
  * Plugin URI:         https://essential-blocks.com
  * Description:     Instantly create beautiful pricing menu for eCommerce website
- * Version:         1.2.7
+ * Version:         1.5.0
  * Author:          WPDeveloper
  * Author URI:         https://wpdeveloper.net
  * License:         GPL-3.0-or-later
  * License URI:     https://www.gnu.org/licenses/gpl-3.0.html
  * Text Domain:     price-table-block
+ * Requires at least: 6.0
+ * Requires PHP:    7.4
  *
  * @package         price-table-block
  */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
 
 /**
  * Registers all block assets so that they can be enqueued through the block editor
@@ -24,11 +31,19 @@
 require_once __DIR__ . '/includes/font-loader.php';
 require_once __DIR__ . '/includes/post-meta.php';
 require_once __DIR__ . '/includes/helpers.php';
-require_once __DIR__ . '/lib/style-handler/style-handler.php';
 
+/**
+ * `lib/style-handler` ships as a git submodule. Guard the require so an
+ * uninitialised submodule degrades gracefully instead of fataling the site.
+ */
+if ( file_exists( __DIR__ . '/lib/style-handler/style-handler.php' ) ) {
+    require_once __DIR__ . '/lib/style-handler/style-handler.php';
+}
+
+if ( ! function_exists( 'create_block_pricing_table_block_init' ) ) {
 function create_block_pricing_table_block_init() {
 
-    define( 'PRICE_TABLE_BLOCKS_VERSION', " 1.2.7" );
+    define( 'PRICE_TABLE_BLOCKS_VERSION', '1.5.0' );
     define( 'PRICE_TABLE_BLOCKS_ADMIN_URL', plugin_dir_url( __FILE__ ) );
     define( 'PRICE_TABLE_BLOCKS_ADMIN_PATH', dirname( __FILE__ ) );
 
@@ -39,9 +54,19 @@ function create_block_pricing_table_block_init() {
         );
     }
 
-    $index_js         = PRICE_TABLE_BLOCKS_ADMIN_URL . 'dist/index.js';
-    $script_asset     = require $script_asset_path;
-    $all_dependencies = array_merge( $script_asset['dependencies'], [
+    $index_js     = PRICE_TABLE_BLOCKS_ADMIN_URL . 'dist/index.js';
+    $script_asset = require $script_asset_path;
+
+    // Generated *.asset.php files are trusted but may be stale/partial.
+    if ( ! is_array( $script_asset ) ) {
+        $script_asset = array();
+    }
+    $asset_dependencies = isset( $script_asset['dependencies'] ) && is_array( $script_asset['dependencies'] )
+        ? $script_asset['dependencies']
+        : array();
+    $asset_version = isset( $script_asset['version'] ) ? $script_asset['version'] : PRICE_TABLE_BLOCKS_VERSION;
+
+    $all_dependencies = array_merge( $asset_dependencies, [
         'wp-blocks',
         'wp-i18n',
         'wp-element',
@@ -54,7 +79,7 @@ function create_block_pricing_table_block_init() {
         'eb-pricing-table-block-editor',
         $index_js,
         $all_dependencies,
-        $script_asset['version']
+        $asset_version
     );
 
     $load_animation_js = PRICE_TABLE_BLOCKS_ADMIN_URL . 'assets/js/eb-animation-load.js';
@@ -78,37 +103,49 @@ function create_block_pricing_table_block_init() {
     wp_register_style(
         'fontpicker-default-theme',
         plugins_url( $fontpicker_theme, __FILE__ ),
-        []
+        [],
+        PRICE_TABLE_BLOCKS_VERSION
     );
 
     $fontpicker_material_theme = 'assets/css/fonticonpicker.material-theme.react.css';
     wp_register_style(
         'fontpicker-matetial-theme',
         plugins_url( $fontpicker_material_theme, __FILE__ ),
-        []
+        [],
+        PRICE_TABLE_BLOCKS_VERSION
     );
 
-    $editor_css = 'dist/style.css';
+    /**
+     * filemtime() emits a warning (PHP 8+) and returns false on a missing file,
+     * which would silently drop the cache-busting version. Fall back to the
+     * plugin version instead.
+     */
+    $editor_css      = 'dist/style.css';
+    $editor_css_path = PRICE_TABLE_BLOCKS_ADMIN_PATH . '/' . $editor_css;
+    $editor_css_ver  = file_exists( $editor_css_path ) ? filemtime( $editor_css_path ) : PRICE_TABLE_BLOCKS_VERSION;
     wp_register_style(
         'eb-pricing-table-block-editor-style',
         plugins_url( $editor_css, __FILE__ ),
         ['fontawesome-frontend-css', 'fontpicker-default-theme', 'fontpicker-matetial-theme'],
-        filemtime( PRICE_TABLE_BLOCKS_ADMIN_PATH . "/$editor_css" )
+        $editor_css_ver
     );
 
     $fontawesome_css = 'assets/css/font-awesome5.css';
     wp_register_style(
         'fontawesome-frontend-css',
         plugins_url( $fontawesome_css, __FILE__ ),
-        []
+        [],
+        PRICE_TABLE_BLOCKS_VERSION
     );
 
-    $style_css = PRICE_TABLE_BLOCKS_ADMIN_URL . 'dist/style.css';
+    $style_css      = PRICE_TABLE_BLOCKS_ADMIN_URL . 'dist/style.css';
+    $style_css_path = PRICE_TABLE_BLOCKS_ADMIN_PATH . '/dist/style.css';
+    $style_css_ver  = file_exists( $style_css_path ) ? filemtime( $style_css_path ) : PRICE_TABLE_BLOCKS_VERSION;
     wp_register_style(
         'create-block-pricing-table-block',
         $style_css,
         ['fontawesome-frontend-css', 'essential-blocks-animation'],
-        filemtime( PRICE_TABLE_BLOCKS_ADMIN_PATH . '/dist/style.css' )
+        $style_css_ver
     );
 
     if ( ! WP_Block_Type_Registry::get_instance()->is_registered( 'essential-blocks/pricing-table' ) ) {
@@ -127,5 +164,6 @@ function create_block_pricing_table_block_init() {
             ]
         );
     }
+}
 }
 add_action( 'init', 'create_block_pricing_table_block_init' );

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,10 @@
 === Price Table Block ===
 Contributors: wpdevteam, re_enter_rupok, Asif2BD, rahat89, fencermonir
 Tags: block, blocks, price, pricing, discount, offers, price table, pricing table, gutenberg, gutenberg blocks
-Requires at least: 5.6
-Tested up to: 6.5
-Stable tag:  1.2.7
+Requires at least: 6.0
+Tested up to: 7.0
+Requires PHP: 7.4
+Stable tag: 1.5.0
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -62,6 +63,15 @@ Yes, it will work with any standard WordPress theme.
 
 
 == Changelog ==
+
+= 1.5.0 - 09/08/2026 =
+* Changed: minimum requirements raised to WordPress 6.0 and PHP 7.4
+* Fixed: responsive (tablet/mobile) styles not applying in the editor preview
+* Fixed: fatal error on PHP 7.x caused by the PHP 8 only str_contains() call
+* Fixed: fatal error when the bundled style-handler library is missing
+* Fixed: block registration on WordPress 5.7
+* Fixed: PHP 8 warnings from asset version lookups and block attribute parsing
+* Improved: compatibility tested up to WordPress 7.0 and PHP 8.5
 
 = 1.2.7 - 15/04/2024 =
 * Fixed: files missing error


### PR DESCRIPTION
## Summary

Frontend styling for the Pricing Table block was completely non-functional, and the plugin fataled on parts of its own declared support range. This fixes both and refreshes the compatibility metadata to WP 6.0+ / PHP 7.4+ at version 1.5.0.

## Why the frontend had no styles

`save.js` emits no `<style>` tag — the saved markup carries only `blockId` classes. The real chain is:

1. `edit.js` renders `<Style/>` → `StyleComponent` generates the CSS into the block's **`blockMeta`** attribute
2. `lib/style-handler` parses post content on `save_post`/`wp` and writes `uploads/eb-style/eb-style-<id>.min.css`
3. `enqueue_frontend_assets()` enqueues that file

`lib/style-handler` is a git submodule, and an uninitialised checkout made step 2 fatal on `require_once`. That kills **every** styling control — background, typography, padding, border, ribbon — not just background colour. The editor preview still looked right because step 1 runs independently.

The require is now guarded with `file_exists()` so a missing submodule degrades gracefully instead of taking the site down.

## Editor bug: responsive styles discarded

`StyleComponent` builds the editor preview's media queries from `EssentialBlocksLocalize.responsiveBreakpoints`, which was never localized. The shipped `dist/modules.js` therefore emitted `@media all and (max-width: undefinedpx)` — invalid, so all tablet and mobile rules were dropped in the editor. The frontend was unaffected because the style handler builds those queries in PHP.

Added `Price_Table_Helper::get_responsive_breakpoints()`, mirroring `EbStyleHandlerParseCss::get_responsive_breakpoints()` — same `eb_settings` option, same 1024/767 defaults, same JSON-string handling — but read-only, since it runs on every admin enqueue.

> The same omission exists in `button-group`, `number-counter`, `image-gallery-block`, `infobox` and `flipbox`.

## Compatibility fixes

| Issue | Broke on |
|---|---|
| `str_contains()` (PHP 8.0; WP polyfills only from 5.9) | fatal on PHP 7.x + WP 5.6–5.8 |
| `include_once` bool return used as an array | `TypeError` on PHP 8 |
| `(float) get_bloginfo('version') <= 5.6` gating block registration | block never registered on WP 5.7; lossy for any x.10 release |
| `filemtime()` / `*.asset.php` reads unguarded | PHP 8 warnings, version silently `false` |
| raw `$_SERVER['QUERY_STRING']`, null font families | sanitisation; PHP 8.1 null-deprecations |
| no `ABSPATH` guard, no redeclare guard | hardening |

`get_block_register_path()` now uses `version_compare(…, '5.8', '>=')`. Note `strpos()` is deliberate and must stay — `str_contains()` is PHP 8.0 and the floor is 7.4.

## Distribution size

Dropped orphaned Font Awesome **4** webfonts (`FontAwesome.otf`, `fontawesome-webfont.*` — referenced by no CSS, JS, PHP or src) and the legacy `.eot`/`.svg` formats, which no browser capable of running the block editor requests. `.distignore` was also reorganised and now excludes the submodule's `.git` gitlink file.

**2.2M → 891K** (5.39 MB → 2.12 MB uncompressed). All FA5 families keep woff2 + woff + ttf.

## Testing

Verified live against **WordPress 7.0.3 / PHP 8.2.29**:

- `save_post` → CSS file written with desktop `#ff0000`, tablet `#00ff00` @1024, mobile `#0000ff` @767
- frontend enqueues `eb-block-style-<id>-css`; stylesheet serves HTTP 200 with the expected background
- editor localize payload — 16 assertions pass; breakpoints are ints and **match the frontend exactly**
- font loader against null / numeric / `"Default"` / empty values — 13 assertions pass
- `php -l` clean; compat smoke across WP 6.0, 6.5, 6.10, 7.0.3 clean

**Not tested:** the editor UI itself — no browser automation available, so no colour picker was actually clicked. The editor half is verified by asserting the exact `EssentialBlocksLocalize` payload the editor JS receives. Worth a manual pass before release.

## Notes

- `package-lock.json` version fields were stale (`" 1.2.6"` / `"1.2.5"`); now synced to `1.5.0`.
- `dist/frontend.js` is built but never enqueued by any PHP — dead output, left alone.
- `all_blocks` is deliberately **not** localized: an empty value could clobber real data from the main Essential Blocks plugin and break its block-visibility filtering.
- Full write-up in `compatibility-report.md` (excluded from the distributed zip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)