### PR TITLE
chore: correct 1.3.0 release date and drop "EB" prefix from description

### DIFF
--- a/block.json
+++ b/block.json
@@ -16,6 +16,6 @@
 		"eb",
 		"plan"
 	],
-	"description": "EB Pricing Table will let you create effective product pricing table with perfect styling to get more sales from your prospective buyers.",
+	"description": "Pricing Table will let you create effective product pricing table with perfect styling to get more sales from your prospective buyers.",
 	"textdomain": "price-table-block"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "pricing-table",
 	"version": "1.3.0",
-	"description": "EB Pricing Table will let you create effective product pricing table with perfect styling to get more sales from your prospective buyers.",
+	"description": "Pricing Table will let you create effective product pricing table with perfect styling to get more sales from your prospective buyers.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-3.0-or-later",
 	"main": "Gruntfile.js",

--- a/readme.txt
+++ b/readme.txt
@@ -64,7 +64,7 @@ Yes, it will work with any standard WordPress theme.
 
 == Changelog ==
 
-= 1.3.0 - 23/08/2026 =
+= 1.3.0 - 25/08/2026 =
 * Fixed: PHP 8.0–8.5 compatibility issues
 * Fixed: WordPress version detection
 * Fixed: PHP 7.x compatibility


### PR DESCRIPTION
Small metadata cleanup on top of `latest`.

## Changes

**`readme.txt`** — corrects the 1.3.0 changelog date from `23/08/2026` to `25/08/2026`, the actual release date. Format matches the surrounding entries (`DD/MM/YYYY`, as in `= 1.2.7 - 15/04/2024 =`).

**`block.json` / `package.json`** — drops the `EB ` prefix from the block description so both files read:

> Pricing Table will let you create effective product pricing table with perfect styling to get more sales from your prospective buyers.

## Notes

- No code, asset or build changes — metadata only, so `dist/` is untouched.
- `Stable tag: 1.3.0` in `readme.txt` is a version, not a date, and is left as-is.
- The description change was already present in the working tree from a parallel edit; it was deliberately kept out of #17 and is folded in here instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UqNpsYoNorKrK5kXRgjNFk